### PR TITLE
chore: drop support for Node.js 0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "version": "0.1.1",
   "private": false,
   "engines": {
-    "node": ">=0.6"
+    "node": ">= 4"
   },
   "author": {
     "name": "Markus Felten",


### PR DESCRIPTION
BREAKING CHANGE: This module no longer supports Node.js 0.10